### PR TITLE
fix: override default ElectraForkVersion in prysm

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,6 +37,10 @@ CAPELLA_FORK_EPOCH: 0
 DENEB_FORK_VERSION: 0x50000001
 DENEB_FORK_EPOCH: 1
 
+# Electra
+ELECTRA_FORK_VERSION: 0x60000001
+ELECTRA_FORK_EPOCH: 18446744073709551615
+
 # Time parameters
 # ---------------------------------------------------------------
 # 12 seconds


### PR DESCRIPTION
fix:
```
validator-1  | time="2024-10-15 07:59:01" level=fatal msg="version 0x05000000 for fork electra in config endurance conflicts with existing config named=mainnet: configset cannot add config with conflicting fork version schedule" prefix=main
validator-1 exited with code 1
```

ref: https://github.com/prysmaticlabs/prysm/commit/751117a3088e3aa52f14be40364e65a1f5706325#diff-a3ec56335b051ab014ad1ab6830e5bc019da9c15d7e7a210bc45bc5b55aa4b60L94